### PR TITLE
auth url params

### DIFF
--- a/my_custom_templates/lib/kinde_sdk.dart
+++ b/my_custom_templates/lib/kinde_sdk.dart
@@ -1,6 +1,7 @@
 library kinde_sdk;
 
 export './src/auth_config.dart';
+export './src/auth_url_params.dart';
 export './src/kinde_flutter_sdk.dart';
 export './src/model/auth_flow_type.dart';
 export './src/model/token_type.dart';

--- a/my_custom_templates/lib/src/auth_url_params.dart
+++ b/my_custom_templates/lib/src/auth_url_params.dart
@@ -1,0 +1,35 @@
+class AuthUrlParams {
+  static const _lang = 'lang';
+  static const _loginHint = 'login_hint';
+  static const _connectionId = 'connection_id';
+
+  /// Language to display for login page
+  String? lang;
+
+  /// Email or phone-number to pre-fill login page
+  String? loginHint;
+
+  /// Connection id string corresponding to social sign in
+  String? connectionId;
+
+  AuthUrlParams({
+    this.lang,
+    this.loginHint,
+    this.connectionId,
+  });
+
+  Map<String, String> toMap() {
+    final params = <String, String>{};
+    if (lang != null) {
+      params[_lang] = lang!;
+    }
+    if (loginHint != null) {
+      params[_loginHint] = loginHint!;
+    }
+    if (connectionId != null) {
+      params[_connectionId] = connectionId!;
+    }
+
+    return params;
+  }
+}

--- a/my_custom_templates/lib/src/kinde_flutter_sdk.dart
+++ b/my_custom_templates/lib/src/kinde_flutter_sdk.dart
@@ -158,8 +158,16 @@ class KindeFlutterSDK with TokenUtils, HandleNetworkMixin {
     await Store.instance.clear();
   }
 
-  Future<String?> login({AuthFlowType? type, String? orgCode}) async {
-    return _redirectToKinde(type: type, orgCode: orgCode);
+  Future<String?> login({
+    AuthFlowType? type,
+    String? orgCode,
+    AuthUrlParams? authUrlParams,
+  }) async {
+    return _redirectToKinde(
+      type: type,
+      orgCode: orgCode,
+      additionalParams: authUrlParams?.toMap() ?? {},
+    );
   }
 
   Future<String?> _redirectToKinde(
@@ -181,10 +189,20 @@ class KindeFlutterSDK with TokenUtils, HandleNetworkMixin {
     }
   }
 
-  Future<void> register({AuthFlowType? type, String? orgCode}) async {
-    await _redirectToKinde(type: type, orgCode: orgCode, additionalParams: {
+  Future<void> register({
+    AuthFlowType? type,
+    String? orgCode,
+    AuthUrlParams? authUrlParams,
+  }) async {
+    final additionalParams = {
       _registrationPageParamName: _registrationPageParamValue
-    });
+    };
+    if (authUrlParams != null) {
+      additionalParams.addAll(authUrlParams.toMap());
+    }
+
+    await _redirectToKinde(
+        type: type, orgCode: orgCode, additionalParams: additionalParams);
   }
 
   Future<UserProfileV2?> getUserProfileV2() async {


### PR DESCRIPTION
Added support for additional auth url params for `register` and `login` operations: 

```
  /// Language to display for login page
  String? lang;

  /// Email or phone-number to pre-fill login page
  String? loginHint;

  /// Connection id string corresponding to social sign in
  String? connectionId;
  ```